### PR TITLE
Use `S6_STAGE2_HOOK` and `longrun` types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,15 @@ FROM lsiobase/ubuntu:noble
 # Pulling TARGET_ARCH from build arguments and setting ENV variable
 ARG TARGETARCH
 ENV ARCH_VAR=$TARGETARCH
+ENV S6_STAGE2_HOOK=/app/init.sh
 
 # Add Supervisor
 RUN apt-get update && apt-get install -y \
-    supervisor \
     libssl3 \
     libssl-dev \
     unzip
 COPY root/ /
+COPY /src /app
 
 # Grab latest version of the app, extract binaries, cleanup tmp dir
 RUN if [ "$ARCH_VAR" = "amd64" ]; then ARCH_VAR=linux-x86_64; elif [ "$ARCH_VAR" = "arm64" ]; then ARCH_VAR=linux-aarch64; fi \

--- a/root/etc/s6-overlay/s6-rc.d/svc-aircast/type
+++ b/root/etc/s6-overlay/s6-rc.d/svc-aircast/type
@@ -1,1 +1,1 @@
-oneshot
+longrun

--- a/root/etc/s6-overlay/s6-rc.d/svc-airupnp/type
+++ b/root/etc/s6-overlay/s6-rc.d/svc-airupnp/type
@@ -1,1 +1,1 @@
-oneshot
+longrun

--- a/src/init.sh
+++ b/src/init.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/with-contenv bash
+
+echo "[init] Reading environment variables..."
+if [ "$AIRCAST_VAR" = "kill" ]; then
+  echo "[init] Setting svc-aircast to oneshot"
+  echo "oneshot" > /etc/s6-overlay/s6-rc.d/svc-aircast/type
+elif [ "$AIRUPNP_VAR" = "kill" ]; then
+  echo "[init] Setting svc-airupnp to oneshot"
+  echo "oneshot" > /etc/s6-overlay/s6-rc.d/svc-airupnp/type
+fi
+echo "[init] Finished reading environment variables"


### PR DESCRIPTION
Adds a script for changing the service type (before the services are created) based on passed env. The result is `oneshot` types for `airupnp` if passed `AIRUPNP_VAR=kill` or the same for `AIRCAST_VAR=kill`. This also resolves https://github.com/1activegeek/docker-airconnect/issues/67

```bash
docker run --rm --name docker-airconnect -d -e AIRUPNP_VAR=kill `docker build . -q`
docker exec docker-airconnect /bin/bash -c "s6-rc -a list | grep svc-air"
# svc-aircast
# svc-airupnp
```

Inspecting the status:

```bash
docker run --rm --name docker-airconnect -d -e AIRUPNP_VAR=kill `docker build . -q`
docker exec docker-airconnect /bin/bash -c "s6-svstat /var/run/service/svc-aircast"
# up (pid 46 pgid 46) 7 seconds
docker exec docker-airconnect /bin/bash -c "s6-svstat /var/run/service/svc-airupnp"
# s6-svstat: fatal: unable to read status for /var/run/service/svc-airupnp: s6-supervise not running
```

Alternatively:

```bash
docker run --rm --name docker-airconnect -d -e AIRCAST_VAR=kill `docker build . -q`
docker exec docker-airconnect /bin/bash -c "s6-svstat /var/run/service/svc-airupnp"
# up (pid 46 pgid 46) 10 seconds
docker exec docker-airconnect /bin/bash -c "s6-svstat /var/run/service/svc-aircast"
# s6-svstat: fatal: unable to read status for /var/run/service/svc-aircast: s6-supervise not running
```
