### PR TITLE
Adds libatomic1 package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV S6_STAGE2_HOOK=/app/init.sh
 RUN apt-get update && apt-get install -y \
     libssl3 \
     libssl-dev \
-    unzip
+    unzip \
+    libatomic1
 COPY root/ /
 COPY /src /app
 


### PR DESCRIPTION
This addresses the following error in #74, but on my NanoPI R6S (arm64)

```
/usr/bin/airupnp-docker: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
```